### PR TITLE
Fixes #4: Use k3s_cluster (no dashes) for inventory name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add the system information gathered above into a file called hosts.ini. For exam
 [node]
 192.16.35.[10:11]
 
-[k3s-cluster:children]
+[k3s_cluster:children]
 master
 node
 

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -7,6 +7,6 @@
 192.168.1.16
 192.168.1.32
 
-[k3s-cluster:children]
+[k3s_cluster:children]
 master
 node

--- a/reset.yml
+++ b/reset.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: k3s-cluster
+- hosts: k3s_cluster
   gather_facts: yes
   become: yes
   roles:

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: k3s-cluster
+- hosts: k3s_cluster
   gather_facts: yes
   become: yes
   roles:


### PR DESCRIPTION
Closes #4.﻿
