### PR TITLE
iptables-legacy for Raspian Buster

### DIFF
--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -20,7 +20,7 @@
   iptables:
     flush: true
   when:
-    - ansible_facts.distribution_release is search("buster")
+    - ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster")
 
 - name: Changing to iptables-legacy for Raspbian Buster
   alternatives:
@@ -28,7 +28,7 @@
     name: iptables
   register: ip6_legacy
   when:
-    - ansible_facts.distribution_release is search("buster")
+    - ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster")
 
 - name: Changing to ip6tables-legacy for Raspbian Buster
   alternatives:
@@ -36,7 +36,7 @@
     name: ip6tables
   register: ip4_legacy
   when:
-    - ansible_facts.distribution_release is search("buster")
+    - ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster")
 
 - name: Rebooting on Raspbian
   reboot:

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -16,8 +16,35 @@
     - ansible_facts.architecture is search("arm")
   register: boot_cmdline
 
+- name: Flush iptables before changing iptables-legacy
+  shell:
+    cmd: 'iptables -F'
+  register: flush_iptables
+  changed_when:
+    - flush_iptables.rc == 0 and flush_iptables.stdout != ""
+  when:
+    - ansible_facts.distribution_release is search("buster")
+
+- name: Changing to iptables-legacy for Raspbian Buster
+  alternatives:
+    path: /usr/sbin/iptables-legacy
+    name: iptables
+  register: ip6_legacy
+  when:
+    - ansible_facts.distribution_release is search("buster")
+
+- name: Changing to ip6tables-legacy for Raspbian Buster
+  alternatives:
+    path: /usr/sbin/ip6tables-legacy
+    name: ip6tables
+  register: ip4_legacy
+  when:
+    - ansible_facts.distribution_release is search("buster")
+
 - name: Rebooting on Raspbian
   reboot:
   when:
     - boot_cmdline is changed
     - ansible_facts.architecture is search("arm")
+    - ip6_legacy is changed
+    - ip4_legacy is changed

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -21,7 +21,7 @@
     cmd: 'iptables -F'
   register: flush_iptables
   changed_when:
-    - flush_iptables.rc == 0 and flush_iptables.stdout != ""
+    - flush_iptables.rc == 0 and flush_iptables.stdout_lines.count == 0
   when:
     - ansible_facts.distribution_release is search("buster")
 

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -17,11 +17,8 @@
   register: boot_cmdline
 
 - name: Flush iptables before changing iptables-legacy
-  shell:
-    cmd: 'iptables -F'
-  register: flush_iptables
-  changed_when:
-    - flush_iptables.rc == 0 and flush_iptables.stdout_lines.count == 0
+  iptables:
+    flush: true
   when:
     - ansible_facts.distribution_release is search("buster")
 


### PR DESCRIPTION
Fixes #28 - Changing to iptables-legacy and ip6tables-legacy only for Buster