### PR TITLE
Fix Raspbian role to run correctly on Python 3.x (e.g. Ubuntu 20.04) Ansible host

### DIFF
--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -5,7 +5,7 @@
       ( ansible_facts.architecture is search("arm") and
         ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) or
       ( ansible_facts.architecture is search("aarch64") and
-        ansible_facts.lsb.description is match("Debian.*buster") ) %}true{% else %}false{% endif %}'
+        ansible_facts.lsb.description is match("Debian.*buster") ) %}True{% else %}False{% endif %}'
 
 - name: Activating cgroup support
   lineinfile:
@@ -13,32 +13,27 @@
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Flush iptables before changing to iptables-legacy
   iptables:
     flush: true
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Changing to iptables-legacy
   alternatives:
     path: /usr/sbin/iptables-legacy
     name: iptables
   register: ip4_legacy
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Changing to ip6tables-legacy
   alternatives:
     path: /usr/sbin/ip6tables-legacy
     name: ip6tables
   register: ip6_legacy
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Rebooting
   reboot:
-  when:
-    - raspbian is true
+  when: raspbian


### PR DESCRIPTION
Fix https://github.com/rancher/k3s-ansible/issues/40 .  New version works on both Python 2.x hosts (e.g. Debian 10, which it was previously working on) as well as Python 3.x hosts (e.g. Ubuntu 20.04, which it was broken on prior to this PR).