### PR TITLE
Fix cgroups on ubuntu x86 (Issue 40)

### DIFF
--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -5,7 +5,7 @@
       ( ansible_facts.architecture is search("arm") and
         ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) or
       ( ansible_facts.architecture is search("aarch64") and
-        ansible_facts.lsb.description is match("Debian.*buster") ) %}true{% else %}false{% endif %}'
+        ansible_facts.lsb.description is match("Debian.*buster") ) %}True{% else %}False{% endif %}'
 
 - name: Activating cgroup support
   lineinfile:
@@ -13,32 +13,27 @@
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Flush iptables before changing to iptables-legacy
   iptables:
     flush: true
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Changing to iptables-legacy
   alternatives:
     path: /usr/sbin/iptables-legacy
     name: iptables
   register: ip4_legacy
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Changing to ip6tables-legacy
   alternatives:
     path: /usr/sbin/ip6tables-legacy
     name: ip6tables
   register: ip6_legacy
-  when:
-    - raspbian is true
+  when: raspbian
 
 - name: Rebooting
   reboot:
-  when:
-    - raspbian is true
+  when: raspbian

--- a/roles/ubuntu/tasks/main.yml
+++ b/roles/ubuntu/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Enable cgroup via boot commandline if not already enabled
+- name: Enable cgroup via boot commandline if not already enabled for Ubuntu on ARM
   lineinfile:
     path: /boot/firmware/cmdline.txt
     backrefs: yes
@@ -7,8 +7,12 @@
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   when:
     - ansible_distribution == 'Ubuntu'
+    - ( ansible_facts.architecture is search("arm") or
+        ansible_facts.architecture is search("aarch64") )
 
-- name: Reboot to enable cgroups
+- name: Reboot to enable cgroups for Ubuntu on ARM
   reboot:
   when:
     - ansible_distribution == 'Ubuntu'
+    - ( ansible_facts.architecture is search("arm") or
+        ansible_facts.architecture is search("aarch64") )


### PR DESCRIPTION
Fix for issues #40 and #49.  In both issues the problem is that while Ubuntu on RPi seems to need cgroup enabled, it doesn't need enabling on x86_64, and furthermore, the method of enabling on RPi breaks on x86_64.

Note that this also incorporates PR https://github.com/rancher/k3s-ansible/pull/42, so review and accept that PR request first for smaller PRs.