### PR TITLE
Fixed Raspbian detection on 64-bit kernel, made reboot only do so if needed

### DIFF
--- a/roles/raspbian/handlers/main.yml
+++ b/roles/raspbian/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reboot
+  reboot:

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -5,7 +5,8 @@
       ( ansible_facts.architecture is search("arm") and
         ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) or
       ( ansible_facts.architecture is search("aarch64") and
-        ansible_facts.lsb.description is match("Debian.*buster") ) %}True{% else %}False{% endif %}'
+        ansible_facts.lsb.description is match("Debian.*buster") or
+        ansible_facts.lsb.description is match("[Rr]aspbian.*[Bb]uster") ) %}true{% else %}false{% endif %}'
 
 - name: Activating cgroup support
   lineinfile:
@@ -13,7 +14,9 @@
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
-  when: raspbian
+  register: cgroup
+  when:
+    - raspbian is true
 
 - name: Flush iptables before changing to iptables-legacy
   iptables:
@@ -36,4 +39,7 @@
 
 - name: Rebooting
   reboot:
-  when: raspbian
+  when:
+    - cgroup.changed
+  tags:
+    - skip_ansible_lint

--- a/roles/raspbian/tasks/main.yml
+++ b/roles/raspbian/tasks/main.yml
@@ -14,7 +14,7 @@
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true
-  register: cgroup
+  notify: reboot
   when:
     - raspbian is true
 
@@ -22,6 +22,7 @@
   iptables:
     flush: true
   when: raspbian
+  changed_when: false   # iptables flush always returns changed
 
 - name: Changing to iptables-legacy
   alternatives:
@@ -36,10 +37,3 @@
     name: ip6tables
   register: ip6_legacy
   when: raspbian
-
-- name: Rebooting
-  reboot:
-  when:
-    - cgroup.changed
-  tags:
-    - skip_ansible_lint

--- a/site.yml
+++ b/site.yml
@@ -8,9 +8,6 @@
     - role: download
     - role: raspbian
     - role: ubuntu
-  handlers:
-    - name: reboot
-      reboot:
 
 - hosts: master
   become: yes

--- a/site.yml
+++ b/site.yml
@@ -8,6 +8,9 @@
     - role: download
     - role: raspbian
     - role: ubuntu
+  handlers:
+    - name: reboot
+      reboot:
 
 - hosts: master
   become: yes


### PR DESCRIPTION
Tested on a cluster of Raspberry Pi 3 and Raspberry Pi 4, all running Raspbian with a 64-bit kernel (`arm_64bit=1` in /boot/config.txt)