### PR TITLE
Armbian support

### DIFF
--- a/roles/armbian/tasks/main.yml
+++ b/roles/armbian/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Enable cgroup via boot commandline if not already enabled for Ubuntu on ARM
+  lineinfile:
+    path: /boot/firmware/cmdline.txt
+    backrefs: yes
+    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
+    line: '\1 cgroup_enable\=cpuset cgroup_memory\=1 cgroup_enable\=memory'
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ( ansible_facts.architecture is search("arm") or
+        ansible_facts.architecture is search("aarch64") )
+
+- name: Reboot to enable cgroups for Ubuntu on ARM
+  reboot:
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ( ansible_facts.architecture is search("arm") or
+        ansible_facts.architecture is search("aarch64") )

--- a/roles/armbian/tasks/main.yml
+++ b/roles/armbian/tasks/main.yml
@@ -1,18 +1,5 @@
 ---
-- name: Enable cgroup via boot commandline if not already enabled for Ubuntu on ARM
-  lineinfile:
-    path: /boot/firmware/cmdline.txt
-    backrefs: yes
-    regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
-    line: '\1 cgroup_enable\=cpuset cgroup_memory\=1 cgroup_enable\=memory'
-  when:
-    - ansible_distribution == 'Ubuntu'
-    - ( ansible_facts.architecture is search("arm") or
-        ansible_facts.architecture is search("aarch64") )
-
-- name: Reboot to enable cgroups for Ubuntu on ARM
-  reboot:
-  when:
-    - ansible_distribution == 'Ubuntu'
-    - ( ansible_facts.architecture is search("arm") or
-        ansible_facts.architecture is search("aarch64") )
+- name: Check for Armbian boot commandline file
+  stat:
+    path: /boot/arbianEnv.txt
+  register: stat_result

--- a/roles/ubuntu/tasks/main.yml
+++ b/roles/ubuntu/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check for Ubuntu boot commandline file
+  stat:
+    path: /boot/firmware/cmdline.txt
+  register: stat_result
+
 - name: Enable cgroup via boot commandline if not already enabled for Ubuntu on ARM
   lineinfile:
     path: /boot/firmware/cmdline.txt
@@ -7,6 +12,7 @@
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   when:
     - ansible_distribution == 'Ubuntu'
+    - stat_result.stat.exists
     - ( ansible_facts.architecture is search("arm") or
         ansible_facts.architecture is search("aarch64") )
 
@@ -14,5 +20,6 @@
   reboot:
   when:
     - ansible_distribution == 'Ubuntu'
+    - stat_result.stat.exists
     - ( ansible_facts.architecture is search("arm") or
         ansible_facts.architecture is search("aarch64") )

--- a/site.yml
+++ b/site.yml
@@ -7,6 +7,7 @@
     - role: prereq
     - role: download
     - role: raspbian
+    - role: armbian
     - role: ubuntu
 
 - hosts: master


### PR DESCRIPTION
Armbian, while Ubuntu, handles kernel flags a bit differently, resulting in k3s-ansible failing with a file not found error during that part of the playbook.

Also it appears that all of the cgroup flags that k3s needs are already on by default (at least on the 2 Armbian kernels I have in my little cluster).

I was able to spool up a cluster with these settings.