### PR TITLE
Use checksum with get_url

### DIFF
--- a/roles/download/tasks/main.yml
+++ b/roles/download/tasks/main.yml
@@ -1,13 +1,9 @@
 ---
 
-- name: Delete k3s if already present
-  file:
-    path: /usr/local/bin/k3s
-    state: absent
-
 - name: Download k3s binary x64
   get_url:
     url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s
+    checksum: sha256:https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -17,6 +13,7 @@
 - name: Download k3s binary arm64
   get_url:
     url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-arm64
+    checksum: sha256:https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/sha256sum-arm64.txt
     dest: /usr/local/bin/k3s
     owner: root
     group: root
@@ -29,6 +26,7 @@
 - name: Download k3s binary armhf
   get_url:
     url: https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/k3s-armhf
+    checksum: sha256:https://github.com/rancher/k3s/releases/download/{{ k3s_version }}/sha256sum-arm.txt
     dest: /usr/local/bin/k3s
     owner: root
     group: root

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -49,6 +49,7 @@
     path: ~{{ ansible_user }}/.kube
     state: directory
     owner: "{{ ansible_user }}"
+    mode: "u=rwx,g=rx,o="
 
 - name: Copy config file to user home directory
   copy:
@@ -56,6 +57,7 @@
     dest: ~{{ ansible_user }}/.kube/config
     remote_src: yes
     owner: "{{ ansible_user }}"
+    mode: "u=rw,g=,o="
 
 - name: Replace https://localhost:6443 by https://master-ip:6443
   command: >-

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -22,6 +22,7 @@
   copy:
     content: "br_netfilter"
     dest: /etc/modules-load.d/br_netfilter.conf
+    mode: "u=rw,g=,o="
   when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
 
 - name: Load br_netfilter


### PR DESCRIPTION
When the checksum is used there is no need to delete the binary first, 
as it will be compared to the checksum and downloaded and replaced only 
as needed.

Fixes #67